### PR TITLE
Fix the itunes image tag for the feed artwork.

### DIFF
--- a/Castanet/Feed.php
+++ b/Castanet/Feed.php
@@ -390,14 +390,14 @@ class Castanet_Feed
 		if ($this->image_url != '') {
 			$document = $parent->ownerDocument;
 
-			$text = $document->createTextNode($this->image_url);
-			$node = $document->createElementNS(
+			$image_node = $document->createElementNS(
 				Castanet::ITUNES_NAMESPACE,
 				'image'
 			);
 
-			$node->appendChild($text);
-			$parent->appendChild($node);
+			$image_node->setAttribute('href', $this->image_url);
+
+			$parent->appendChild($image_node);
 		}
 	}
 


### PR DESCRIPTION
Apple's specs clearly state the image url must be on the href attribute. See https://www.apple.com/itunes/podcasts/specs.html#image
