### PR TITLE
Fix podcast feed validation

### DIFF
--- a/Castanet.php
+++ b/Castanet.php
@@ -19,5 +19,7 @@ abstract class Castanet
 
 	const ITUNES_NAMESPACE = 'http://www.itunes.com/dtds/podcast-1.0.dtd';
 
+	const ATOM_NAMESPACE = 'http://www.w3.org/2005/Atom';
+
 	// }}}
 }

--- a/Castanet/Feed.php
+++ b/Castanet/Feed.php
@@ -74,6 +74,11 @@ class Castanet_Feed
 	/**
 	 * @var string
 	 */
+	protected $itunes_owner;
+
+	/**
+	 * @var string
+	 */
 	protected $atom_link;
 
 	/**
@@ -184,11 +189,19 @@ class Castanet_Feed
 	}
 
 	// }}}
-	// {{{ public function setItunesAuthor()
+	// {{{ public function setItunesOwnerEmail()
 
-	public function setItunesEmail($itunes_email)
+	public function setItunesOwnerEmail($itunes_email)
 	{
 		$this->itunes_email = strval($itunes_email);
+	}
+
+	// }}}
+	// {{{ public function setItunesOwner()
+
+	public function setItunesOwner($itunes_owner)
+	{
+		$this->itunes_owner = strval($itunes_owner);
 	}
 
 	// }}}
@@ -249,7 +262,7 @@ class Castanet_Feed
 		$this->buildImage($channel);
 		$this->buildManagingEditor($channel);
 		$this->buildItunesAuthor($channel);
-		$this->buildItunesEmail($channel);
+		$this->buildItunesOwner($channel);
 		$this->buildItunesImage($channel);
 		$this->buildItunesExplicit($channel);
 		$this->buildItunesBlock($channel);
@@ -301,21 +314,38 @@ class Castanet_Feed
 	}
 
 	// }}}
-	// {{{ protected function buildItunesEmail()
+	// {{{ protected function buildItunesOwner()
 
-	protected function buildItunesEmail(DOMNode $parent)
+	protected function buildItunesOwner(DOMNode $parent)
 	{
-		if ($this->managing_editor != '') {
+		if ($this->itunes_email != '' || $this->itunes_owner != '') {
 			$document = $parent->ownerDocument;
 
-			$text = $document->createTextNode($this->itunes_email);
 			$node = $document->createElementNS(
 				Castanet::ITUNES_NAMESPACE,
-				'email'
+				'owner'
 			);
 
+			if($this->itunes_email!= ''){
+				$text = $document->createTextNode($this->itunes_email);
+				$child_node = $document->createElementNS(
+					Castanet::ITUNES_NAMESPACE,
+					'email'
+				);
+				$child_node->appendChild($text);
+				$node->appendChild($child_node);
+			}
 
-			$node->appendChild($text);
+			if($this->itunes_owner!= ''){
+				$text = $document->createTextNode($this->itunes_owner);
+				$child_node = $document->createElementNS(
+					Castanet::ITUNES_NAMESPACE,
+					'name'
+				);
+				$child_node->appendChild($text);
+				$node->appendChild($child_node);
+			}
+
 			$parent->appendChild($node);
 		}
 	}

--- a/Castanet/Feed.php
+++ b/Castanet/Feed.php
@@ -49,12 +49,12 @@ class Castanet_Feed
 	/**
 	 * @var string
 	 */
-	protected $image_url;
+	protected $itunes_image_url;
 
 	/**
-	 * @var integer
+	 * @var string
 	 */
-	protected $small_image_url;
+	protected $image_url;
 
 	/**
 	 * @var integer
@@ -82,9 +82,9 @@ class Castanet_Feed
 	protected $itunes_owner;
 
 	/**
-	 * @var string
+	 * @var array
 	 */
-	protected $itunes_category;
+	protected $itunes_categories = array();
 
 	/**
 	 * @var string
@@ -170,21 +170,21 @@ class Castanet_Feed
 	}
 
 	// }}}
-	// {{{ public function setImage()
+	// {{{ public function setItunesImage()
 
-	public function setImage($url)
+	public function setItunesImage($url)
 	{
 		// For Apple-sized images (1400x1400 px and up, always square)
-		$this->image_url = strval($url);
+		$this->itunes_image_url = strval($url);
 	}
 
 	// }}}
 	// {{{ public function setImage()
 
-	public function setSmallImage($url, $width, $height)
+	public function setImage($url, $width, $height)
 	{
 		// For standard RSS images (max 144x400 px)
-		$this->small_image_url = strval($url);
+		$this->image_url = strval($url);
 		$this->image_width = intval($width);
 		$this->image_height = intval($height);
 	}
@@ -214,12 +214,14 @@ class Castanet_Feed
 	}
 
 	// }}}
-	// {{{ public function setItunesCategory()
+	// {{{ public function setItunesCategories()
 
-	public function setItunesCategory($itunes_category, $itunes_subcategory)
+	public function setItunesCategories($itunes_categories)
 	{
-		$this->itunes_category = strval($itunes_category);
-		$this->itunes_subcategory = strval($itunes_subcategory);
+		$this->itunes_categories = array();
+		foreach($itunes_categories as $subcategory){
+			$this->itunes_categories[] = strval($subcategory);
+		}
 	}
 
 	// }}}
@@ -295,7 +297,7 @@ class Castanet_Feed
 		$this->buildCopyright($channel);
 		$this->buildImage($channel);
 		$this->buildManagingEditor($channel);
-		$this->buildItunesCategory($channel);
+		$this->buildItunesCategories($channel);
 		$this->buildItunesAuthor($channel);
 		$this->buildItunesOwner($channel);
 		$this->buildItunesImage($channel);
@@ -361,7 +363,7 @@ class Castanet_Feed
 				'owner'
 			);
 
-			if ($this->itunes_email != ''){
+			if ($this->itunes_email != '') {
 				$text = $document->createTextNode($this->itunes_email);
 				$child_node = $document->createElementNS(
 					Castanet::ITUNES_NAMESPACE,
@@ -371,7 +373,7 @@ class Castanet_Feed
 				$node->appendChild($child_node);
 			}
 
-			if ($this->itunes_owner != ''){
+			if ($this->itunes_owner != '') {
 				$text = $document->createTextNode($this->itunes_owner);
 				$child_node = $document->createElementNS(
 					Castanet::ITUNES_NAMESPACE,
@@ -386,31 +388,20 @@ class Castanet_Feed
 	}
 
 	// }}}
-	// {{{ protected function buildItunesCategory()
+	// {{{ protected function buildItunesCategories()
 
-	protected function buildItunesCategory(DOMNode $parent)
+	protected function buildItunesCategories(DOMNode $parent)
 	{
-		if ($this->itunes_category != '') {
-			$document = $parent->ownerDocument;
-
-			$node = $document->createElementNS(
+		$document = $parent->ownerDocument;
+		foreach($this->itunes_categories as $subcategory){
+			$child_node = $document->createElementNS(
 				Castanet::ITUNES_NAMESPACE,
 				'category'
 			);
-			$node->setAttribute('text', $this->itunes_category); 
 
-
-			if ($this->itunes_subcategory != ''){
-				$child_node = $document->createElementNS(
-					Castanet::ITUNES_NAMESPACE,
-					'category'
-				);
-
-				$child_node->setAttribute('text', $this->itunes_subcategory); 
-				$node->appendChild($child_node);
-			}
-
-			$parent->appendChild($node);
+			$child_node->setAttribute('text', $subcategory); 
+			$parent->appendChild($child_node);
+			$parent = $child_node;
 		}
 	}
 
@@ -549,7 +540,7 @@ class Castanet_Feed
 
 	protected function buildItunesImage(DOMNode $parent)
 	{
-		if ($this->image_url != '') {
+		if ($this->itunes_image_url != '') {
 			$document = $parent->ownerDocument;
 
 			$image_node = $document->createElementNS(
@@ -557,7 +548,7 @@ class Castanet_Feed
 				'image'
 			);
 
-			$image_node->setAttribute('href', $this->image_url);
+			$image_node->setAttribute('href', $this->itunes_image_url);
 
 			$parent->appendChild($image_node);
 		}
@@ -569,13 +560,13 @@ class Castanet_Feed
 	protected function buildImage(DOMNode $parent)
 	{
 		// The standard RSS image element should be a max of 144x400px
-		if ($this->small_image_url != '') {
+		if ($this->image_url != '') {
 			$document = $parent->ownerDocument;
 
 			$image_node = $document->createElement('image');
 			$parent->appendChild($image_node);
 
-			$node = $document->createElement('url', $this->small_image_url);
+			$node = $document->createElement('url', $this->image_url);
 			$image_node->appendChild($node);
 
 			$title = $document->createTextNode($this->title);

--- a/Castanet/Feed.php
+++ b/Castanet/Feed.php
@@ -79,6 +79,16 @@ class Castanet_Feed
 	/**
 	 * @var string
 	 */
+	protected $itunes_category;
+
+	/**
+	 * @var string
+	 */
+	protected $itunes_subcategory;
+
+	/**
+	 * @var string
+	 */
 	protected $atom_link;
 
 	/**
@@ -189,6 +199,15 @@ class Castanet_Feed
 	}
 
 	// }}}
+	// {{{ public function setItunesCategory()
+
+	public function setItunesCategory($itunes_category, $itunes_subcategory)
+	{
+		$this->itunes_category = strval($itunes_category);
+		$this->itunes_subcategory = strval($itunes_subcategory);
+	}
+
+	// }}}
 	// {{{ public function setItunesOwnerEmail()
 
 	public function setItunesOwnerEmail($itunes_email)
@@ -261,6 +280,7 @@ class Castanet_Feed
 		$this->buildCopyright($channel);
 		$this->buildImage($channel);
 		$this->buildManagingEditor($channel);
+		$this->buildItunesCategory($channel);
 		$this->buildItunesAuthor($channel);
 		$this->buildItunesOwner($channel);
 		$this->buildItunesImage($channel);
@@ -343,6 +363,35 @@ class Castanet_Feed
 					'name'
 				);
 				$child_node->appendChild($text);
+				$node->appendChild($child_node);
+			}
+
+			$parent->appendChild($node);
+		}
+	}
+
+	// }}}
+	// {{{ protected function buildItunesCategory()
+
+	protected function buildItunesCategory(DOMNode $parent)
+	{
+		if ($this->itunes_category != '') {
+			$document = $parent->ownerDocument;
+
+			$node = $document->createElementNS(
+				Castanet::ITUNES_NAMESPACE,
+				'category'
+			);
+			$node->setAttribute('text', $this->itunes_category); 
+
+
+			if($this->itunes_subcategory!= ''){
+				$child_node = $document->createElementNS(
+					Castanet::ITUNES_NAMESPACE,
+					'category'
+				);
+
+				$child_node->setAttribute('text', $this->itunes_subcategory); 
 				$node->appendChild($child_node);
 			}
 

--- a/Castanet/Feed.php
+++ b/Castanet/Feed.php
@@ -54,6 +54,11 @@ class Castanet_Feed
 	/**
 	 * @var integer
 	 */
+	protected $small_image_url;
+
+	/**
+	 * @var integer
+	 */
 	protected $image_width;
 
 	/**
@@ -167,9 +172,19 @@ class Castanet_Feed
 	// }}}
 	// {{{ public function setImage()
 
-	public function setImage($url, $width, $height)
+	public function setImage($url)
 	{
+		// For Apple-sized images (1400x1400 px and up, always square)
 		$this->image_url = strval($url);
+	}
+
+	// }}}
+	// {{{ public function setImage()
+
+	public function setSmallImage($url, $width, $height)
+	{
+		// For standard RSS images (max 144x400 px)
+		$this->small_image_url = strval($url);
 		$this->image_width = intval($width);
 		$this->image_height = intval($height);
 	}
@@ -553,13 +568,14 @@ class Castanet_Feed
 
 	protected function buildImage(DOMNode $parent)
 	{
-		if ($this->image_url != '') {
+		// The standard RSS image element should be a max of 144x400px
+		if ($this->small_image_url != '') {
 			$document = $parent->ownerDocument;
 
 			$image_node = $document->createElement('image');
 			$parent->appendChild($image_node);
 
-			$node = $document->createElement('url', $this->image_url);
+			$node = $document->createElement('url', $this->small_image_url);
 			$image_node->appendChild($node);
 
 			$title = $document->createTextNode($this->title);

--- a/Castanet/Feed.php
+++ b/Castanet/Feed.php
@@ -67,6 +67,11 @@ class Castanet_Feed
 	protected $itunes_author;
 
 	/**
+	 * @var string
+	 */
+	protected $atom_link;
+
+	/**
 	 * @var boolean
 	 */
 	protected $itunes_explicit = false;
@@ -166,6 +171,14 @@ class Castanet_Feed
 	}
 
 	// }}}
+	// {{{ public function setAtomLink()
+
+	public function setAtomLink($atom_link)
+	{
+		$this->atom_link = strval($atom_link);
+	}
+
+	// }}}
 	// {{{ public function setItunesAuthor()
 
 	public function setItunesAuthor($itunes_author)
@@ -215,6 +228,7 @@ class Castanet_Feed
 		$parent->appendChild($channel);
 
 		$this->buildTitle($channel);
+		$this->buildAtomLink($channel);
 		$this->buildLink($channel);
 		$this->buildDescription($channel);
 		$this->buildLanguage($channel);
@@ -287,6 +301,26 @@ class Castanet_Feed
 			);
 
 			$node->appendChild($text);
+			$parent->appendChild($node);
+		}
+	}
+
+	// }}}
+	// {{{ protected function buildAtomLink()
+
+	protected function buildAtomLink(DOMNode $parent)
+	{
+		if ($this->atom_link != '') {
+			$document = $parent->ownerDocument;
+
+			$node = $document->createElementNS(
+				Castanet::ATOM_NAMESPACE,
+				'link'
+			);
+			$image_node->setAttribute('href', $this->atom_link); 
+			$image_node->setAttribute('rel', 'self');
+			$image_node->setAttribute('type', 'application/rss+xml');
+
 			$parent->appendChild($node);
 		}
 	}

--- a/Castanet/Feed.php
+++ b/Castanet/Feed.php
@@ -221,15 +221,13 @@ class Castanet_Feed
 	// }}}
 	// {{{ public function setItunesCategories()
 
-	public function setItunesCategories($itunes_category, array $itunes_subcategories = null)
+	public function setItunesCategories($itunes_category, array $itunes_subcategories = array())
 	{
 		$this->itunes_category = $itunes_category;
 
 		$this->itunes_subcategories = array();
-		if (!is_null($itunes_subcategories)) {
-			foreach ($itunes_subcategories as $subcategory) {
-				$this->itunes_subcategories[] = strval($subcategory);
-			}
+		foreach ($itunes_subcategories as $subcategory) {
+			$this->itunes_subcategories[] = strval($subcategory);
 		}
 	}
 

--- a/Castanet/Feed.php
+++ b/Castanet/Feed.php
@@ -351,9 +351,9 @@ class Castanet_Feed
 				Castanet::ATOM_NAMESPACE,
 				'link'
 			);
-			$image_node->setAttribute('href', $this->atom_link); 
-			$image_node->setAttribute('rel', 'self');
-			$image_node->setAttribute('type', 'application/rss+xml');
+			$node->setAttribute('href', $this->atom_link); 
+			$node->setAttribute('rel', 'self');
+			$node->setAttribute('type', 'application/rss+xml');
 
 			$parent->appendChild($node);
 		}

--- a/Castanet/Feed.php
+++ b/Castanet/Feed.php
@@ -69,6 +69,11 @@ class Castanet_Feed
 	/**
 	 * @var string
 	 */
+	protected $itunes_email;
+
+	/**
+	 * @var string
+	 */
 	protected $atom_link;
 
 	/**
@@ -181,6 +186,14 @@ class Castanet_Feed
 	// }}}
 	// {{{ public function setItunesAuthor()
 
+	public function setItunesEmail($itunes_email)
+	{
+		$this->itunes_email = strval($itunes_email);
+	}
+
+	// }}}
+	// {{{ public function setItunesAuthor()
+
 	public function setItunesAuthor($itunes_author)
 	{
 		$this->itunes_author = strval($itunes_author);
@@ -236,6 +249,7 @@ class Castanet_Feed
 		$this->buildImage($channel);
 		$this->buildManagingEditor($channel);
 		$this->buildItunesAuthor($channel);
+		$this->buildItunesEmail($channel);
 		$this->buildItunesImage($channel);
 		$this->buildItunesExplicit($channel);
 		$this->buildItunesBlock($channel);
@@ -280,6 +294,26 @@ class Castanet_Feed
 
 			$text = $document->createTextNode($this->managing_editor);
 			$node = $document->createElement('managingEditor');
+
+			$node->appendChild($text);
+			$parent->appendChild($node);
+		}
+	}
+
+	// }}}
+	// {{{ protected function buildItunesEmail()
+
+	protected function buildItunesEmail(DOMNode $parent)
+	{
+		if ($this->managing_editor != '') {
+			$document = $parent->ownerDocument;
+
+			$text = $document->createTextNode($this->itunes_email);
+			$node = $document->createElementNS(
+				Castanet::ITUNES_NAMESPACE,
+				'email'
+			);
+
 
 			$node->appendChild($text);
 			$parent->appendChild($node);

--- a/Castanet/Feed.php
+++ b/Castanet/Feed.php
@@ -361,7 +361,7 @@ class Castanet_Feed
 				'owner'
 			);
 
-			if($this->itunes_email!= ''){
+			if ($this->itunes_email != ''){
 				$text = $document->createTextNode($this->itunes_email);
 				$child_node = $document->createElementNS(
 					Castanet::ITUNES_NAMESPACE,
@@ -371,7 +371,7 @@ class Castanet_Feed
 				$node->appendChild($child_node);
 			}
 
-			if($this->itunes_owner!= ''){
+			if ($this->itunes_owner != ''){
 				$text = $document->createTextNode($this->itunes_owner);
 				$child_node = $document->createElementNS(
 					Castanet::ITUNES_NAMESPACE,
@@ -400,7 +400,7 @@ class Castanet_Feed
 			$node->setAttribute('text', $this->itunes_category); 
 
 
-			if($this->itunes_subcategory!= ''){
+			if ($this->itunes_subcategory != ''){
 				$child_node = $document->createElementNS(
 					Castanet::ITUNES_NAMESPACE,
 					'category'

--- a/Castanet/Feed.php
+++ b/Castanet/Feed.php
@@ -82,9 +82,14 @@ class Castanet_Feed
 	protected $itunes_owner;
 
 	/**
+	 * @var string
+	 */
+	protected $itunes_category;
+
+	/**
 	 * @var array
 	 */
-	protected $itunes_categories = array();
+	protected $itunes_subcategories = array();
 
 	/**
 	 * @var string
@@ -216,11 +221,15 @@ class Castanet_Feed
 	// }}}
 	// {{{ public function setItunesCategories()
 
-	public function setItunesCategories($itunes_categories)
+	public function setItunesCategories($itunes_category, array $itunes_subcategories = null)
 	{
-		$this->itunes_categories = array();
-		foreach($itunes_categories as $subcategory){
-			$this->itunes_categories[] = strval($subcategory);
+		$this->itunes_category = $itunes_category;
+
+		$this->itunes_subcategories = array();
+		if (!is_null($itunes_subcategories)) {
+			foreach ($itunes_subcategories as $subcategory) {
+				$this->itunes_subcategories[] = strval($subcategory);
+			}
 		}
 	}
 
@@ -393,15 +402,21 @@ class Castanet_Feed
 	protected function buildItunesCategories(DOMNode $parent)
 	{
 		$document = $parent->ownerDocument;
-		foreach($this->itunes_categories as $subcategory){
+		$node = $document->createElementNS(
+			Castanet::ITUNES_NAMESPACE,
+			'category'
+		);
+		$node->setAttribute('text', $this->itunes_category); 
+		$parent->appendChild($node);
+
+		foreach ($this->itunes_subcategories as $subcategory) {
 			$child_node = $document->createElementNS(
 				Castanet::ITUNES_NAMESPACE,
 				'category'
 			);
 
 			$child_node->setAttribute('text', $subcategory); 
-			$parent->appendChild($child_node);
-			$parent = $child_node;
+			$node->appendChild($child_node);
 		}
 	}
 

--- a/Castanet/Item.php
+++ b/Castanet/Item.php
@@ -246,7 +246,7 @@ class Castanet_Item
 			$node = $document->createElement('guid');
 
 			if (!$this->guid_is_permalink) {
-				$node->setAttribute('isPermalink', 'false');
+				$node->setAttribute('isPermaLink', 'false');
 			}
 
 			$node->appendChild($text);


### PR DESCRIPTION
https://trello.com/c/BwwJUmnu/1471-0-5d-minor-issues-with-podcast-feed-validation

Fixes some feed validation errors in our raps podcasts:

- Split image into a small and large version of the image (one for the default RSS image which is a max of 144 px wide, one for the Apple version which is 1400x1400 and up) 
- Correct guid attribute "isPermalink" to "isPermaLink"
- Add an atom:link element with a direct link to the RSS resource
- Add itunes:category element with another itunes:category subelement (the subcategory) 
- Add itunes:owner element with itunes:email and itunes:name subelements